### PR TITLE
refactor(aws-direct-connect): 文字列のタイトルケース変換を改善

### DIFF
--- a/lib/aws-direct-connect-virtual-interface.go
+++ b/lib/aws-direct-connect-virtual-interface.go
@@ -17,6 +17,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	mp "github.com/mackerelio/go-mackerel-plugin"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // AwsDxVifPlugin struct
@@ -42,8 +44,8 @@ type metrics struct {
 
 // GraphDefinition : return graph definition
 func (p AwsDxVifPlugin) GraphDefinition() map[string]mp.Graphs {
-	labelPrefix := strings.Title(p.Prefix)
-	labelPrefix = strings.Replace(labelPrefix, "-", " ", -1)
+	labelPrefix := cases.Title(language.Und, cases.NoLower).String(p.Prefix)
+	labelPrefix = strings.ReplaceAll(labelPrefix, "-", " ")
 
 	// https://docs.aws.amazon.com/directconnect/latest/UserGuide/monitoring-cloudwatch.html#viewing-metrics
 	return map[string]mp.Graphs{


### PR DESCRIPTION
- strings.Titleを非推奨のため、golang.org/x/text/casesを使用するよう変更
- strings.Replaceをstrings.ReplaceAllに置き換え、コードの簡潔性を向上